### PR TITLE
Release 0.1.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "benches/revm-comparison"]
 
 [package]
 name = "curve-math"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 rust-version = "1.80"
 description = "Pure Rust port of Curve Finance AMM math (StableSwap + CryptoSwap). Wei-level precision, fuzz-verified against on-chain get_dy for 200+ pools."


### PR DESCRIPTION
## Summary
- Version bump to `0.1.0-alpha.1` for initial crates.io publication

## Pre-publish checklist
- [x] No secrets/API keys in code
- [x] Cargo.toml metadata complete (repository, keywords, categories, MSRV)
- [x] Rustdoc with examples
- [x] CI (clippy, fmt, test, fuzz)
- [x] Clean git history (single commit)