### PR TITLE
fix: use auto-detect for MetaPool Factory variant

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -39,7 +39,7 @@ Three legacy factories also use the same `pool_count()` / `pool_list(uint256)` i
 
 | Factory | Address | Variant |
 |---------|---------|---------|
-| MetaPool Factory | `0xB9fC157394Af804a3578134A6585C0dc9cc990d4` | `StableSwapMeta` |
+| MetaPool Factory | `0xB9fC157394Af804a3578134A6585C0dc9cc990d4` | Probe on-chain (see `detect_variant.py`) |
 | CryptoSwap Factory | `0xF18056Bbd320E96A48e3Fbf8bC061322531aac99` | `TwoCryptoV1` |
 | crvUSD StableSwap Factory | `0x4F8846Ae9380B90d2E71D5e3D042dff3E7ebb40d` | Probe on-chain (see `detect_variant.py`) |
 

--- a/tools/index-pools.py
+++ b/tools/index-pools.py
@@ -49,7 +49,7 @@ FACTORIES = {
         # ── Legacy factories ────────────────────────────────────────────
         {
             "address": "0xB9fC157394Af804a3578134A6585C0dc9cc990d4",
-            "variant": "StableSwapMeta",
+            "variant": "auto",
             "label": "MetaPool Factory (legacy)",
         },
         {


### PR DESCRIPTION
## Summary
- MetaPool Factory deploys both meta pools AND plain pools — hardcoding `StableSwapMeta` misclassifies plain pools like CRV/sdCRV
- Change MetaPool Factory variant from `"StableSwapMeta"` to `"auto"` so `detect_variant_onchain()` probes each pool
- CRV/sdCRV verified: detected as StableSwapV2, fuzz passes (44/44 wei-exact)

## Root cause
Scheduled CI run [#23424399817](https://github.com/sunce86/curve-math/actions/runs/23424399817) found CRV/sdCRV from MetaPool Factory, classified it as StableSwapMeta, fuzz failed with ~2% mismatch. The pool has no `base_pool()` — it's a plain StableSwapV2 pool.

## Test plan
- [x] `detect_variant(CRV/sdCRV)` → StableSwapV2 (verified on-chain)
- [x] Fuzz CRV/sdCRV as StableSwapV2: 44 passed, 0 failed