### PR TITLE
fix: use unique delimiter in index-pools CI output

### DIFF
--- a/.github/workflows/index-pools.yml
+++ b/.github/workflows/index-pools.yml
@@ -51,9 +51,10 @@ jobs:
         run: |
           if [ -f .pr-summary.md ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "body<<EOF" >> $GITHUB_OUTPUT
+            echo "body<<ENDOFBODY" >> $GITHUB_OUTPUT
             cat .pr-summary.md >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "" >> $GITHUB_OUTPUT
+            echo "ENDOFBODY" >> $GITHUB_OUTPUT
             rm .pr-summary.md
           else
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/tools/index-pools.py
+++ b/tools/index-pools.py
@@ -510,7 +510,7 @@ def write_pr_summary(verified: int, failed: int, added: list[str], skipped: list
     if not added:
         lines.append("No new pools added.\n")
     lines.append(f"\n> Full fuzz verification runs automatically on this PR.")
-    Path(".pr-summary.md").write_text("\n".join(lines))
+    Path(".pr-summary.md").write_text("\n".join(lines) + "\n")
     print(f"PR summary written to .pr-summary.md")
 
 


### PR DESCRIPTION
The `EOF` delimiter in the PR summary step collides with content in `.pr-summary.md`, causing GitHub Actions to fail with `Invalid value. Matching delimiter not found 'EOF'`.

Use `ENDOFBODY` instead.