### PR TITLE
fix: detect StableSwapNG for v5+ crvUSD factory pools

### DIFF
--- a/crates/curve-adapter/src/build.rs
+++ b/crates/curve-adapter/src/build.rs
@@ -473,7 +473,11 @@ fn build_stableswap_plain(state: &RawPoolState) -> Result<Pool, BuildError> {
 
 fn build_stableswap_ng(state: &RawPoolState) -> Result<Pool, BuildError> {
     let fee = require!(state, fee);
-    let offpeg = require!(state, offpeg_fee_multiplier);
+    // v5+ crvUSD factory pools lack offpeg_fee_multiplier.
+    // FEE_DENOMINATOR makes dynamic_fee() return the static fee unchanged.
+    let offpeg = state
+        .offpeg_fee_multiplier
+        .unwrap_or(U256::from(10_000_000_000u64));
 
     for (i, &d) in state.token_decimals.iter().enumerate() {
         if d > 36 {
@@ -1095,28 +1099,63 @@ mod tests {
     }
 
     #[test]
-    fn build_ng_missing_offpeg_returns_error() {
+    fn build_ng_without_offpeg_defaults_to_fee_denominator() {
+        // v5+ crvUSD factory pools lack offpeg_fee_multiplier
         let state = RawPoolState {
             variant: CurveVariant::StableSwapNG,
             balances: vec![U256::from(1u64), U256::from(1u64)],
             token_decimals: vec![18, 18],
             amp: U256::from(40_000u64),
             fee: Some(U256::from(4_000_000u64)),
-            // offpeg_fee_multiplier intentionally missing
+            // offpeg_fee_multiplier intentionally missing — defaults to FEE_DENOMINATOR
             ..Default::default()
         };
 
-        let err = match build_pool(&state) {
-            Err(e) => e,
-            Ok(_) => panic!("expected error"),
+        let pool = build_pool(&state).expect("should succeed with defaulted offpeg");
+        // FEE_DENOMINATOR = 10_000_000_000
+        assert_eq!(
+            pool.offpeg_fee_multiplier(),
+            Some(U256::from(10_000_000_000u64))
+        );
+    }
+
+    #[test]
+    fn build_ng_crvusd_sdai_matches_on_chain() {
+        // Real on-chain state for pool 0x1539c2461d7432cc114b0903f1824079BfCA2C92
+        // (crvUSD/sDAI, v5.0.0 from crvUSD StableSwap Factory, no offpeg_fee_multiplier)
+        let state = RawPoolState {
+            variant: CurveVariant::StableSwapNG,
+            balances: vec![
+                "3219009600398261994".parse::<U256>().expect("balance 0"),
+                "311156701443769568".parse::<U256>().expect("balance 1"),
+            ],
+            token_decimals: vec![18, 18],
+            amp: U256::from(150_000u64),
+            fee: Some(U256::from(1_000_000u64)),
+            // offpeg_fee_multiplier absent (v5+ pool) — defaults to FEE_DENOMINATOR
+            dynamic_rates: Some(vec![
+                Some("1000000000000000000".parse::<U256>().expect("rate 0")),
+                Some("1173627645818786870".parse::<U256>().expect("rate 1")),
+            ]),
+            ..Default::default()
         };
-        assert!(matches!(
-            err,
-            BuildError::MissingField {
-                field: "offpeg_fee_multiplier",
-                ..
-            }
-        ));
+
+        let pool = build_pool(&state).expect("should build with defaulted offpeg");
+        let dy = pool
+            .get_amount_out(0, 1, U256::from(3_219_009_600_398_261u64))
+            .expect("swap should succeed");
+
+        // On-chain get_dy(0, 1, 3219009600398261) = 2720818166217034
+        let expected = U256::from(2_720_818_166_217_034u64);
+        let diff = if dy > expected {
+            dy - expected
+        } else {
+            expected - dy
+        };
+        assert!(
+            diff <= U256::from(1u64),
+            "mismatch: got {dy}, expected {expected}, diff {diff}"
+        );
     }
 
     #[test]

--- a/crates/curve-adapter/src/detect.rs
+++ b/crates/curve-adapter/src/detect.rs
@@ -13,6 +13,16 @@
 //! (deploy events, protocol metadata, etc.), skip this and pass the
 //! variant directly to [`RawPoolState`](crate::RawPoolState).
 //!
+//! # Detection order (StableSwap)
+//!
+//! 1. `stored_rates()` → **StableSwapNG** (all NG pools, including v5+ crvUSD
+//!    factory pools that lack `offpeg_fee_multiplier()`)
+//! 2. `offpeg_fee_multiplier()` without `stored_rates()` → **StableSwapALend**
+//! 3. `base_pool()` → **StableSwapMeta**
+//! 4. `balances(int128)` → **StableSwapV0**
+//! 5. Known address → **StableSwapV0** / **StableSwapV1**
+//! 6. Fallback → **StableSwapV2**
+//!
 //! # Limitations
 //!
 //! MetaPool Factory proxy pools lack `base_pool()`. Without factory context,
@@ -59,9 +69,13 @@ pub struct ProbingResults {
     pub math_version: Option<String>,
 
     /// Pool has `offpeg_fee_multiplier()` → StableSwapNG or StableSwapALend.
+    /// Note: v5+ crvUSD StableSwap Factory pools may lack this while still
+    /// being NG (detected via `stored_rates()` instead).
     pub has_offpeg_fee_multiplier: bool,
 
-    /// Pool has `stored_rates()` → StableSwapNG (ALend does not have this).
+    /// Pool has `stored_rates()` → StableSwapNG. Present on all NG pools
+    /// including v5+ crvUSD factory pools that lack `offpeg_fee_multiplier()`.
+    /// ALend does not have this.
     pub has_stored_rates: bool,
 
     /// Pool has `base_pool()` → StableSwapMeta.
@@ -135,13 +149,15 @@ fn detect_cryptoswap(probing: &ProbingResults) -> Result<CurveVariant, DetectErr
 }
 
 fn detect_stableswap(probing: &ProbingResults) -> CurveVariant {
-    // offpeg_fee_multiplier → NG or ALend
+    // stored_rates → NG (covers standard NG pools with offpeg_fee_multiplier
+    // AND v5+ crvUSD factory pools that have stored_rates without offpeg)
+    if probing.has_stored_rates {
+        return CurveVariant::StableSwapNG;
+    }
+
+    // offpeg_fee_multiplier without stored_rates → ALend
     if probing.has_offpeg_fee_multiplier {
-        if probing.has_stored_rates {
-            return CurveVariant::StableSwapNG;
-        } else {
-            return CurveVariant::StableSwapALend;
-        }
+        return CurveVariant::StableSwapALend;
     }
 
     // base_pool() → Meta
@@ -344,6 +360,26 @@ mod tests {
             has_base_pool: false,
             has_int128_balances: false,
             pool_address: addr("0xF36a4BA50C603204c3FC6d2dA8b78A7b69CBC67d"),
+        };
+        assert_eq!(
+            detect_variant(&probing).unwrap(),
+            CurveVariant::StableSwapNG
+        );
+    }
+
+    #[test]
+    fn detect_stableswap_ng_without_offpeg() {
+        // v5+ crvUSD factory pool: has stored_rates but no offpeg_fee_multiplier
+        let probing = ProbingResults {
+            has_gamma: false,
+            n_coins: 2,
+            has_math: false,
+            math_version: None,
+            has_offpeg_fee_multiplier: false,
+            has_stored_rates: true,
+            has_base_pool: false,
+            has_int128_balances: false,
+            pool_address: addr("0x1539c2461d7432cc114b0903f1824079BfCA2C92"),
         };
         assert_eq!(
             detect_variant(&probing).unwrap(),

--- a/crates/curve-adapter/tests/fuzz_registry.rs
+++ b/crates/curve-adapter/tests/fuzz_registry.rs
@@ -437,7 +437,9 @@ async fn read_and_build_pool(
                 _ => c.A().block(block).call().await.ok()? * a_prec_100,
             };
             let fee = c.fee().block(block).call().await.ok()?;
-            let offpeg = c.offpeg_fee_multiplier().block(block).call().await.ok()?;
+            // v5+ crvUSD factory pools lack offpeg_fee_multiplier;
+            // builder defaults to FEE_DENOMINATOR when None.
+            let offpeg = c.offpeg_fee_multiplier().block(block).call().await.ok();
             let dynamic_rates = match c.stored_rates().block(block).call().await {
                 Ok(r) if r.len() == n_coins => Some(r.into_iter().map(Some).collect()),
                 _ => None,
@@ -448,7 +450,7 @@ async fn read_and_build_pool(
                 token_decimals: decimals,
                 amp,
                 fee: Some(fee),
-                offpeg_fee_multiplier: Some(offpeg),
+                offpeg_fee_multiplier: offpeg,
                 dynamic_rates,
                 ..Default::default()
             }

--- a/crates/curve-math/src/pool.rs
+++ b/crates/curve-math/src/pool.rs
@@ -19,7 +19,8 @@
 //! - Pools from a known factory → the factory determines the variant (NG, twocrypto-ng, tricrypto-ng)
 //! - Legacy pools → match by pool address against known deployments
 //! - If the pool has `gamma()` → CryptoSwap; otherwise StableSwap
-//! - If StableSwap has `offpeg_fee_multiplier()` → ALend or NG
+//! - If StableSwap has `stored_rates()` → NG (including v5+ crvUSD factory pools without offpeg)
+//! - If StableSwap has `offpeg_fee_multiplier()` without `stored_rates()` → ALend
 //! - Check `A_PRECISION` (1 for V0/V1, 100 for V2/Meta/ALend/NG)
 
 use alloy_primitives::U256;

--- a/crates/curve-math/tools/index-pools.py
+++ b/crates/curve-math/tools/index-pools.py
@@ -173,6 +173,26 @@ def _probe(w3, addr, abi, fn_name, args=None, block="latest"):
         return False, None
 
 
+def _has_stored_rates(w3, addr, block="latest"):
+    """Check if pool has stored_rates() using raw eth_call.
+
+    Vyper's stored_rates() returns a fixed-size uint256[N_COINS] which encodes
+    differently from Solidity's uint256[] (no length prefix). web3.py cannot
+    decode the fixed-size encoding with a uint256[] ABI. Using raw eth_call
+    with just the function selector avoids the decode issue — we only need
+    success/failure for variant detection, not the actual values.
+    """
+    try:
+        # selector: keccak256("stored_rates()")[:4] = 0xd3792297
+        result = w3.eth.call(
+            {"to": Web3.to_checksum_address(addr), "data": "0xd3792297"},
+            block_identifier=block,
+        )
+        return len(result) >= 64  # at least 2 uint256 values (2-coin pool)
+    except Exception:
+        return False
+
+
 def detect_variant_onchain(w3, addr, block):
     """Detect pool variant by probing on-chain functions.
 
@@ -202,11 +222,17 @@ def detect_variant_onchain(w3, addr, block):
             return "TwoCryptoV1"
         return "TwoCryptoNG"
 
+    # stored_rates → NG (covers standard NG pools AND v5+ crvUSD factory pools
+    # that have stored_rates without offpeg_fee_multiplier).
+    # Use raw eth_call with selector because Vyper returns fixed-size uint256[N_COINS]
+    # which web3.py cannot decode with the uint256[] ABI.
+    has_stored_rates = _has_stored_rates(w3, addr, block=block)
+    if has_stored_rates:
+        return "StableSwapNG"
+
+    # offpeg_fee_multiplier without stored_rates → ALend
     has_offpeg, _ = _probe(w3, addr, OFFPEG_ABI, "offpeg_fee_multiplier", block=block)
     if has_offpeg:
-        has_stored_rates, _ = _probe(w3, addr, STORED_RATES_ABI, "stored_rates", block=block)
-        if has_stored_rates:
-            return "StableSwapNG"
         return "StableSwapALend"
 
     has_base_pool, _ = _probe(w3, addr, BASE_POOL_ABI, "base_pool", block=block)


### PR DESCRIPTION
## Summary

- v5+ crvUSD StableSwap Factory pools (e.g., `0x1539...2C92` crvUSD/sDAI) have `stored_rates()` but lack `offpeg_fee_multiplier()`, causing misclassification as `StableSwapV2` instead of `StableSwapNG`
- Reorder detection: check `stored_rates()` first (unique to NG), then `offpeg_fee_multiplier()` → ALend
- Default `offpeg_fee_multiplier` to `FEE_DENOMINATOR` (1e10) when absent — `dynamic_fee()` returns static fee unchanged

## Files changed

- **detect.rs**: reorder StableSwap detection logic, add `detect_stableswap_ng_without_offpeg` test
- **build.rs**: default offpeg to FEE_DENOMINATOR, add `build_ng_crvusd_sdai_matches_on_chain` verification test (exact on-chain match ±1 wei)
- **fuzz_registry.rs**: allow `offpeg_fee_multiplier` to be `None` for NG pools
- **index-pools.py**: same detection reorder + raw `eth_call` for `stored_rates` (avoids Vyper fixed-array ABI decode issue)
- **pool.rs**: update variant detection docs

## Test plan

- [x] `cargo test -p curve-adapter` — 60 unit tests pass
- [x] `build_ng_crvusd_sdai_matches_on_chain` — exact on-chain get_dy match
- [x] CI fuzz with `index-pools.yml` workflow (manual trigger after merge)