### PR TITLE
fix: correct stored_rates() function selector in index-pools.py

### DIFF
--- a/crates/curve-math/tools/index-pools.py
+++ b/crates/curve-math/tools/index-pools.py
@@ -183,9 +183,9 @@ def _has_stored_rates(w3, addr, block="latest"):
     success/failure for variant detection, not the actual values.
     """
     try:
-        # selector: keccak256("stored_rates()")[:4] = 0xd3792297
+        # selector: keccak256("stored_rates()")[:4] = 0xfd0684b1
         result = w3.eth.call(
-            {"to": Web3.to_checksum_address(addr), "data": "0xd3792297"},
+            {"to": Web3.to_checksum_address(addr), "data": "0xfd0684b1"},
             block_identifier=block,
         )
         return len(result) >= 64  # at least 2 uint256 values (2-coin pool)


### PR DESCRIPTION
## Summary

- `_has_stored_rates()` used wrong selector `0xd3792297` instead of `0xfd0684b1` (`keccak256("stored_rates()")[:4]`)
- This caused the function to always return False, so v5+ crvUSD factory pools were still classified as StableSwapV2
- One-line fix: correct the selector

## Test plan

- [ ] Trigger `index-pools.yml` after merge — crvUSD/sDAI should now be classified as StableSwapNG and pass fuzz