### PR TITLE
fix: correct working directory for PR summary in index-pools

### DIFF
--- a/.github/workflows/index-pools.yml
+++ b/.github/workflows/index-pools.yml
@@ -48,6 +48,7 @@ jobs:
 
       - name: Read PR summary
         id: summary
+        working-directory: crates/curve-adapter
         run: |
           if [ -f .pr-summary.md ]; then
             echo "has_changes=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- \"Discover new pools\" runs in `crates/curve-adapter/` where Python writes `.pr-summary.md`
- \"Read PR summary\" ran in repo root — file not found → `has_changes=false` → PR never created
- Fix: add `working-directory: crates/curve-adapter` to the summary step

This explains why the last successful Index Pools run (60 new pools found, all fuzz-verified) did not create a PR.