### PR TITLE
fix: use full variant detection for MetaPool Factory plain pools

### DIFF
--- a/crates/curve-math/tools/index-pools.py
+++ b/crates/curve-math/tools/index-pools.py
@@ -407,12 +407,23 @@ def discover_pools(w3, factory_cfg, existing_addrs, max_new, block):
                     abi=FACTORY_ABI,
                 )
                 is_meta = fc.functions.is_meta(Web3.to_checksum_address(addr)).call(block_identifier=block)
-                variant = "StableSwapMeta" if is_meta else "StableSwapV2"
+                if is_meta:
+                    variant = "StableSwapMeta"
+                else:
+                    # Non-meta plain pools may still have stored_rates (oracle pools).
+                    # Use full detection to classify correctly.
+                    variant = detect_variant_onchain(w3, addr, block)
             except Exception:
                 variant = detect_variant_onchain(w3, addr, block)
         # Auto-detect variant by probing on-chain functions
         elif variant == "auto":
             variant = detect_variant_onchain(w3, addr, block)
+
+        # None = unsupported variant (e.g. unsupported coin count)
+        if variant is None:
+            name = "/".join(symbols)
+            print(f"    {addr} {name} ({len(coins)}-coin, SKIP: unsupported variant)")
+            continue
 
         name = "/".join(symbols)
         print(f"    {addr} {name} ({len(coins)}-coin, {variant})")


### PR DESCRIPTION
## Summary

- MetaPool Factory non-meta pools were hardcoded as `StableSwapV2`, bypassing `stored_rates()` detection
- Pools like ETH/ETHx (`0x59Ab5a5b5d617E478a2479B0cAD80DA7e2831492`) that have `stored_rates()` were misclassified, causing ~8.5% swap mismatch in fuzz tests
- Now uses `detect_variant_onchain()` for non-meta pools, which correctly identifies them as `StableSwapNG`

## Root cause

```python
# Before (line 410):
variant = "StableSwapMeta" if is_meta else "StableSwapV2"  # skips stored_rates() check

# After:
if is_meta:
    variant = "StableSwapMeta"
else:
    variant = detect_variant_onchain(w3, addr, block)  # full detection
```

## Test plan

- [x] Verified ETH/ETHx pool passes fuzz test when classified as StableSwapNG (94/100 passed)
- [x] All unit tests pass (60 curve-adapter + 49 curve-math)
- [ ] CI index-pools workflow should no longer fail on this pool