### PR TITLE
fix: read on-chain precisions for CryptoSwap pools

### DIFF
--- a/crates/curve-adapter/src/build.rs
+++ b/crates/curve-adapter/src/build.rs
@@ -246,6 +246,18 @@ pub struct RawPoolState {
     /// impact is outsized. Every wei of such a token is worth `10^36` in
     /// normalized space.
     pub dynamic_rates: Option<Vec<Option<U256>>>,
+
+    /// On-chain precisions for CryptoSwap variants. **Immutable.**
+    ///
+    /// If `Some`, used directly instead of computing from `token_decimals`.
+    /// Read from the pool contract's `precisions()` getter.
+    ///
+    /// This is important because some tokens report incorrect `decimals()`
+    /// (e.g. Spectra PT tokens), and the factory computes the correct
+    /// precisions at deployment time.
+    ///
+    /// If `None`, precisions are computed as `10^(18 - decimals)`.
+    pub precisions: Option<Vec<U256>>,
 }
 
 impl Default for RawPoolState {
@@ -264,6 +276,7 @@ impl Default for RawPoolState {
             d: None,
             gamma: None,
             dynamic_rates: None,
+            precisions: None,
         }
     }
 }
@@ -562,7 +575,8 @@ fn build_twocrypto(state: &RawPoolState) -> Result<Pool, BuildError> {
     }
     let price_scale = price_scale_vec[0];
 
-    let precisions = compute_crypto_precisions(&state.token_decimals);
+    let default_precs = compute_crypto_precisions(&state.token_decimals);
+    let precisions = state.precisions.as_deref().unwrap_or(&default_precs);
     let balances: [U256; 2] = [state.balances[0], state.balances[1]];
     let prec_arr: [U256; 2] = [precisions[0], precisions[1]];
 
@@ -647,7 +661,8 @@ fn build_tricrypto(state: &RawPoolState) -> Result<Pool, BuildError> {
     }
     let price_scale: [U256; 2] = [price_scale_vec[0], price_scale_vec[1]];
 
-    let precisions = compute_crypto_precisions(&state.token_decimals);
+    let default_precs = compute_crypto_precisions(&state.token_decimals);
+    let precisions = state.precisions.as_deref().unwrap_or(&default_precs);
     let balances: [U256; 3] = [state.balances[0], state.balances[1], state.balances[2]];
     let prec_arr: [U256; 3] = [precisions[0], precisions[1], precisions[2]];
 

--- a/crates/curve-adapter/tests/fuzz_registry.rs
+++ b/crates/curve-adapter/tests/fuzz_registry.rs
@@ -152,6 +152,7 @@ alloy::sol! {
         function mid_fee() external view returns (uint256);
         function out_fee() external view returns (uint256);
         function fee_gamma() external view returns (uint256);
+        function precisions() external view returns (uint256[2]);
     }
 
     #[sol(rpc)]
@@ -165,6 +166,7 @@ alloy::sol! {
         function mid_fee() external view returns (uint256);
         function out_fee() external view returns (uint256);
         function fee_gamma() external view returns (uint256);
+        function precisions() external view returns (uint256[3]);
     }
 }
 
@@ -584,6 +586,7 @@ async fn read_and_build_pool(
             let mid_fee = c.mid_fee().block(block).call().await.ok()?;
             let out_fee = c.out_fee().block(block).call().await.ok()?;
             let fee_gamma = c.fee_gamma().block(block).call().await.ok()?;
+            let precs = c.precisions().block(block).call().await.ok();
             RawPoolState {
                 variant,
                 balances: vec![b0, b1],
@@ -595,6 +598,7 @@ async fn read_and_build_pool(
                 d: Some(d),
                 gamma: Some(gamma),
                 price_scale: Some(vec![ps]),
+                precisions: precs.map(|p| p.to_vec()),
                 ..Default::default()
             }
         }
@@ -608,6 +612,7 @@ async fn read_and_build_pool(
             let mid_fee = c.mid_fee().block(block).call().await.ok()?;
             let out_fee = c.out_fee().block(block).call().await.ok()?;
             let fee_gamma = c.fee_gamma().block(block).call().await.ok()?;
+            let precs = c.precisions().block(block).call().await.ok();
             RawPoolState {
                 variant,
                 balances: vec![b0, b1],
@@ -618,6 +623,7 @@ async fn read_and_build_pool(
                 fee_gamma: Some(fee_gamma),
                 d: Some(d),
                 price_scale: Some(vec![ps]),
+                precisions: precs.map(|p| p.to_vec()),
                 ..Default::default()
             }
         }
@@ -644,6 +650,7 @@ async fn read_and_build_pool(
             let mid_fee = c.mid_fee().block(block).call().await.ok()?;
             let out_fee = c.out_fee().block(block).call().await.ok()?;
             let fee_gamma = c.fee_gamma().block(block).call().await.ok()?;
+            let precs = c.precisions().block(block).call().await.ok();
             RawPoolState {
                 variant,
                 balances: vec![b0, b1, b2],
@@ -655,6 +662,7 @@ async fn read_and_build_pool(
                 d: Some(d),
                 gamma: Some(gamma),
                 price_scale: Some(vec![ps0, ps1]),
+                precisions: precs.map(|p| p.to_vec()),
                 ..Default::default()
             }
         }


### PR DESCRIPTION
## Summary

- Added `precisions` field to `RawPoolState` for CryptoSwap variants
- `build_pool` uses on-chain precisions when provided, falls back to `10^(18-decimals)` for backward compat
- Fuzz test reads `precisions()` from pool contracts for TwoCryptoV1/NG, TwoCryptoStable, and TriCrypto

## Root cause

Some tokens (e.g. Spectra PT) report incorrect `decimals()` — the PT token returns 6 but has balances/supply on 10^18 scale. The Curve factory computes correct precisions at deployment and the pool stores them as `precisions() = [1, 1]`. We were computing `[1, 10^12]` from decimals, causing double-scaling of xp and wildly incorrect swap outputs.

## Test plan

- [x] csUSDL/PT-csUSDL pool passes fuzz (96/100, was failing with `left: 5206737752376226731, right: 2`)
- [x] All 109 unit tests pass