### PR TITLE
docs: warn about balances(i) vs balanceOf divergence

### DIFF
--- a/crates/curve-math/docs/integration.md
+++ b/crates/curve-math/docs/integration.md
@@ -63,6 +63,16 @@ The registry is maintained by the [pool indexer](../tools/index-pools.py) and co
 
 Each variant requires different on-chain state. Some fields change every block, others rarely.
 
+### Balance validation
+
+A pool's internal `balances(i)` can diverge from the actual token balance held by the contract (`ERC20(coins(i)).balanceOf(pool)`). This happens on drained, exploited, or abandoned pools — the internal accounting remains stale while the tokens are gone.
+
+On such pools, `get_dy()` returns a mathematically "correct" result based on stale `balances(i)`, but `exchange()` reverts because the contract cannot transfer tokens it doesn't hold.
+
+**Always verify**: for each coin `i`, check that `ERC20(coins(i)).balanceOf(pool) >= balances(i)`. If any coin fails this check, the pool is in an inconsistent state and swap simulations will produce unreliable results.
+
+This applies to all variants, but is most common on legacy CryptoSwap pools (TwoCryptoV1) and old StableSwap deployments.
+
 ### Per-block state (update on every swap/liquidity event)
 
 | Variant | Fields |


### PR DESCRIPTION
## Summary

- Adds balance validation section to the integration guide
- Documents that `balances(i)` can diverge from `ERC20.balanceOf(pool)` on abandoned/exploited pools
- On such pools, `get_dy()` returns results based on stale state but `exchange()` reverts
- Integrators must check `balanceOf >= balances(i)` for each coin before routing