### PR TITLE
fix: match Vyper D_P truncation order in StableSwapV2 get_d

### DIFF
--- a/crates/curve-math/src/core/stableswap_v2.rs
+++ b/crates/curve-math/src/core/stableswap_v2.rs
@@ -26,8 +26,20 @@ pub fn get_d(xp: &[U256], amp: U256) -> Option<U256> {
 
     for _ in 0..MAX_ITERATIONS {
         let mut d_p = d;
-        for balance in xp {
-            d_p = d_p.checked_mul(d)?.checked_div(balance.checked_mul(n)?)?;
+        if n_coins == 2 {
+            // Plain-2 factory Vyper uses unrolled D_P with different truncation:
+            //   D_P = D * D / xp[0] * D / xp[1] / N_COINS²
+            // Divides by each xp separately, then by N² at the end.
+            for balance in xp {
+                d_p = d_p.checked_mul(d)?.checked_div(*balance)?;
+            }
+            d_p = d_p.checked_div(n.checked_mul(n)?)?;
+        } else {
+            // Plain-3/4 factory Vyper uses per-element loop (same as V0/V1):
+            //   D_P = D_P * D / (x * N_COINS)
+            for balance in xp {
+                d_p = d_p.checked_mul(d)?.checked_div(balance.checked_mul(n)?)?;
+            }
         }
 
         let d_prev = d;

--- a/crates/curve-math/src/swap/stableswap_v2.rs
+++ b/crates/curve-math/src/swap/stableswap_v2.rs
@@ -251,4 +251,22 @@ mod tests {
             "spot price inconsistent with swap"
         );
     }
+
+    /// Regression test: crvUSD/USDM pool at highly imbalanced state (8:1 ratio).
+    /// Previously failed with 1 wei mismatch due to D_P truncation order in get_d.
+    #[test]
+    fn crvusd_usdm_imbalanced() {
+        let balances = [
+            U256::from_str_radix("7997642844895266633", 10).unwrap(),
+            U256::from_str_radix("1200263404327533497", 10).unwrap(),
+        ];
+        let rates = [U256::from(RATE_18), U256::from(RATE_18)];
+        let amp = U256::from(500u64) * A_PRECISION;
+        let fee = U256::from(1_000_000u64);
+        let dx = U256::from_str_radix("7997642844895266", 10).unwrap();
+
+        let result = get_amount_out(&balances, &rates, amp, fee, 0, 1, dx).unwrap();
+        // On-chain value at block ~24800000
+        assert_eq!(result, U256::from(7883635526307528u128));
+    }
 }


### PR DESCRIPTION
## Summary

Factory plain-2 pools (StableSwapV2) compute D_P with unrolled division:
```vyper
D_P = D * D / _xp[0] * D / _xp[1] / (N_COINS)**2
```

Our loop used `D_P *= D / (xp[k] * N)` per element, which has different integer truncation points. This caused ±1 wei divergence on highly imbalanced pools.

## Root cause

Integer division truncation differs:
- Vyper: `D * D / xp[0]` then `* D / xp[1]` then `/ 4`
- Ours: `D * D / (xp[0] * 2)` then `* D / (xp[1] * 2)`

Dividing by `xp[0]` vs `xp[0] * 2` produces different remainders, which cascade through Newton iterations.

## Scope

Only affects **StableSwapV2** (factory plain pools with A_PRECISION=100). V0/V1/Meta/ALend/NG all use the per-element `D_P *= D / (x * N)` loop pattern which matches their Vyper sources.

## Regression test

crvUSD/USDM pool at 8:1 imbalanced state — previously off by 1 wei, now exact match.

## Test plan

- [x] All existing unit tests pass (92 tests)
- [x] crvUSD/USDM regression test passes (wei-exact)
- [ ] Full fuzz registry CI passes