### PR TITLE
fix: model +1 quirk in StableSwapALend get_D denominator

### DIFF
--- a/crates/curve-math/src/core/stableswap_alend.rs
+++ b/crates/curve-math/src/core/stableswap_alend.rs
@@ -25,7 +25,9 @@ pub fn get_d(xp: &[U256], amp: U256) -> Option<U256> {
     for _ in 0..MAX_ITERATIONS {
         let mut d_p = d;
         for balance in xp {
-            d_p = d_p.checked_mul(d)?.checked_div(balance.checked_mul(n)?)?;
+            d_p = d_p
+                .checked_mul(d)?
+                .checked_div(balance.checked_mul(n)?.checked_add(U256::from(1))?)?;
         }
         let d_prev = d;
         let num = ann


### PR DESCRIPTION
## Summary

The Aave-style lending template (`pool-templates/a/SwapTemplateA.vy`) adds `+1` to the `get_D` denominator:

```vyper
D_P = D_P * D / (_x * N_COINS + 1)  # +1 is to prevent /0
```

Every deployed ALend pool inherits this from the template (Aave 3pool, sAAVE, IB, aETH). It is not a per-pool quirk, it is the rule of the ALend math family. The same `+1` already lives in `StableSwapV0` and the new `StableSwapSTETH` variant for parallel reasons.

Without it, our adapter and the on-chain Newton solver converge to a `y` that drifts by 1 wei in some balance regimes, producing wei mismatches at small `dx`.

## Why a single math patch (no flag, no new variant)

Unlike stETH, where the `+1` quirk co-existed with several other deviations (native ETH balance source, payable exchange flow, custom Vyper file) that justified a dedicated `StableSwapSTETH` variant, here every single ALend deployment shares the same template. There is no "ALend without `+1`" pool to model. The fix is therefore a 3-line patch to `core::stableswap_alend::get_d`, with no public API change.

## Verification

Live fuzz on the two ALend pools in the Ethereum registry (`fuzz_1_alend_only` test, 200 iterations per pool, recent block):

| Pool | Before | After |
|---|---|---|
| Aave (aDAI/aUSDC/aUSDT) `0xDeBF20...` | 158 passed (passing by luck) | 157 passed, 41 skipped |
| aDAI/aSUSD `0xEB16Ae...` | **fail** at dx=1 (ours=2 vs chain=1) | 196 passed, 4 skipped |
| Total | flaky | **353 passed, 45 skipped, 0 failed** |

The 9 existing `stableswap_alend` unit tests (5 core + 4 swap) continue to pass.

## Test plan

- [x] `cargo test -p curve-math --features swap stableswap_alend` (9 tests pass)
- [x] Isolated fuzz against on-chain `get_dy` for both ALend pools in registry — wei-exact at all tested dx values
- [ ] CI fuzz across full Ethereum registry (will run on merge)