### PR TITLE
feat: detect TwoCryptoV1 eth_variant via WETH coin and EIP-1167 proxy

### DIFF
--- a/crates/curve-adapter/src/build.rs
+++ b/crates/curve-adapter/src/build.rs
@@ -269,8 +269,11 @@ pub struct RawPoolState {
     /// - `true`  (CurveCryptoSwap2ETH): pools containing WETH — `mul2 = WAD + 2*WAD*K0 / _g1k0`
     /// - `false` (CurveCryptoSwap2): pools without WETH — `mul2 = (WAD + 2*WAD*K0) / _g1k0`
     ///
-    /// Only relevant for `TwoCryptoV1`. Defaults to `true` (ETH variant).
-    pub eth_variant: bool,
+    /// **Required for `TwoCryptoV1`.** `build_pool` returns
+    /// [`BuildError::EthVariantRequired`] if this is `None` and the variant
+    /// is `TwoCryptoV1`. Use [`detect_eth_variant`](crate::detect_eth_variant)
+    /// from `curve_adapter` to determine the value structurally.
+    pub eth_variant: Option<bool>,
 }
 
 impl Default for RawPoolState {
@@ -290,7 +293,7 @@ impl Default for RawPoolState {
             gamma: None,
             dynamic_rates: None,
             precisions: None,
-            eth_variant: true,
+            eth_variant: None,
         }
     }
 }
@@ -606,6 +609,7 @@ fn build_twocrypto(state: &RawPoolState) -> Result<Pool, BuildError> {
     match state.variant {
         CurveVariant::TwoCryptoV1 => {
             let gamma = require!(state, gamma);
+            let eth_variant = require!(state, eth_variant);
             Ok(Pool::TwoCryptoV1 {
                 balances,
                 precisions: prec_arr,
@@ -616,7 +620,7 @@ fn build_twocrypto(state: &RawPoolState) -> Result<Pool, BuildError> {
                 mid_fee,
                 out_fee,
                 fee_gamma,
-                eth_variant: state.eth_variant,
+                eth_variant,
             })
         }
         CurveVariant::TwoCryptoNG => {
@@ -1348,10 +1352,16 @@ mod tests {
             }
         };
 
-        // TwoCryptoV1, TwoCryptoNG
-        for v in [CurveVariant::TwoCryptoV1, CurveVariant::TwoCryptoNG] {
-            assert!(build_pool(&crypto_base(v, 2)).is_ok(), "failed for {v}");
-        }
+        // TwoCryptoV1 (requires explicit eth_variant)
+        let mut tcv1 = crypto_base(CurveVariant::TwoCryptoV1, 2);
+        tcv1.eth_variant = Some(true);
+        assert!(build_pool(&tcv1).is_ok(), "failed for TwoCryptoV1");
+
+        // TwoCryptoNG
+        assert!(
+            build_pool(&crypto_base(CurveVariant::TwoCryptoNG, 2)).is_ok(),
+            "failed for TwoCryptoNG"
+        );
 
         // TwoCryptoStable (no gamma needed)
         let mut tcs = crypto_base(CurveVariant::TwoCryptoStable, 2);
@@ -1521,6 +1531,7 @@ mod tests {
             mid_fee: Some(U256::from(26_000_000u64)),
             out_fee: Some(U256::from(45_000_000u64)),
             fee_gamma: Some(u("230000000000000")),
+            eth_variant: Some(true), // CRV/ETH legacy direct deploy with WETH
             ..Default::default()
         };
         let pool = build_pool(&state).unwrap();

--- a/crates/curve-adapter/src/detect.rs
+++ b/crates/curve-adapter/src/detect.rs
@@ -229,6 +229,80 @@ const KNOWN_STETH: [Address; 1] = [
     address!("DC24316b9AE028F1497c275EB9192a3Ea0f67022"), // Lido stETH/ETH
 ];
 
+/// Standard EIP-1167 minimal proxy bytecode prefix (10 bytes).
+/// Followed by 20 bytes of implementation address, then [`EIP1167_SUFFIX`].
+const EIP1167_PREFIX: &[u8] = b"\x36\x3d\x3d\x37\x3d\x3d\x3d\x36\x3d\x73";
+
+/// Standard EIP-1167 minimal proxy bytecode suffix (15 bytes).
+const EIP1167_SUFFIX: &[u8] = b"\x5a\xf4\x3d\x82\x80\x3e\x90\x3d\x91\x60\x2b\x57\xfd\x5b\xf3";
+
+/// Total length of a standard EIP-1167 minimal proxy.
+const EIP1167_LEN: usize = 45;
+
+/// Returns `true` if `bytecode` is a standard EIP-1167 minimal proxy.
+///
+/// All three checks must pass: exact length, prefix, and suffix. This makes
+/// the false positive rate effectively zero — a non-proxy contract would
+/// have to coincidentally match all 25 fixed bytes at exact positions.
+pub fn is_eip1167_proxy(bytecode: &[u8]) -> bool {
+    bytecode.len() == EIP1167_LEN
+        && bytecode.starts_with(EIP1167_PREFIX)
+        && bytecode.ends_with(EIP1167_SUFFIX)
+}
+
+/// Chains supported by `curve_adapter` detection logic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SupportedChain {
+    /// Ethereum Mainnet (chain ID 1).
+    Mainnet = 1,
+    /// Base (chain ID 8453).
+    Base = 8453,
+    /// Arbitrum One (chain ID 42161).
+    Arbitrum = 42161,
+}
+
+impl SupportedChain {
+    /// Convert a numeric chain ID to a `SupportedChain`. Returns `None` for
+    /// chains the adapter does not yet support.
+    pub fn from_u64(id: u64) -> Option<Self> {
+        match id {
+            1 => Some(Self::Mainnet),
+            8453 => Some(Self::Base),
+            42161 => Some(Self::Arbitrum),
+            _ => None,
+        }
+    }
+
+    /// Wrapped native token address (WETH on EVM chains).
+    pub fn wrapped_native(self) -> Address {
+        match self {
+            Self::Mainnet => address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
+            Self::Base => address!("4200000000000000000000000000000000000006"),
+            Self::Arbitrum => address!("82aF49447D8a07e3bd95BD0d56f35241523fBab1"),
+        }
+    }
+}
+
+/// Detect whether a `TwoCryptoV1` pool uses the ETH variant Newton solver.
+///
+/// `CurveCryptoSwap2ETH.vy` and `CurveCryptoSwap2.vy` differ in one Newton
+/// step (`mul2` formula). Detection rule:
+/// - Factory-deployed pools (EIP-1167 proxies pointing at the CryptoSwap
+///   factory implementation) **always** use the ETH variant, regardless of
+///   coin composition (e.g. CVG/crvFRAX has no WETH but uses ETH math).
+/// - Legacy direct deploys: `CurveCryptoSwap2ETH.vy` was used for
+///   WETH-paired pools (e.g. CRV/ETH); `CurveCryptoSwap2.vy` for the rest.
+///
+/// Combined check: `coins.contains(WETH) || is_eip1167_proxy(bytecode)`.
+///
+/// # Arguments
+/// * `coins` — pool's coin addresses (read from on-chain `coins(i)` getters)
+/// * `pool_bytecode` — runtime bytecode at the pool address (`eth_getCode`)
+/// * `chain` — chain on which the pool is deployed
+pub fn detect_eth_variant(coins: &[Address], pool_bytecode: &[u8], chain: SupportedChain) -> bool {
+    coins.contains(&chain.wrapped_native()) || is_eip1167_proxy(pool_bytecode)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -578,5 +652,115 @@ mod tests {
             detect_variant(&probing).unwrap(),
             CurveVariant::StableSwapV2
         );
+    }
+
+    // ── eth_variant detection ──────────────────────────────────────────────
+
+    fn weth_mainnet() -> Address {
+        addr("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+    }
+
+    /// Build a synthetic 45-byte EIP-1167 proxy with the given implementation address.
+    fn synthetic_proxy(impl_addr: Address) -> Vec<u8> {
+        let mut out = Vec::with_capacity(EIP1167_LEN);
+        out.extend_from_slice(EIP1167_PREFIX);
+        out.extend_from_slice(impl_addr.as_slice());
+        out.extend_from_slice(EIP1167_SUFFIX);
+        out
+    }
+
+    #[test]
+    fn is_eip1167_recognizes_standard_proxy() {
+        let bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
+        assert!(is_eip1167_proxy(&bytecode));
+    }
+
+    #[test]
+    fn is_eip1167_rejects_wrong_length() {
+        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
+        bytecode.push(0x00);
+        assert!(!is_eip1167_proxy(&bytecode));
+    }
+
+    #[test]
+    fn is_eip1167_rejects_corrupted_prefix() {
+        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
+        bytecode[0] = 0xff;
+        assert!(!is_eip1167_proxy(&bytecode));
+    }
+
+    #[test]
+    fn is_eip1167_rejects_corrupted_suffix() {
+        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
+        bytecode[EIP1167_LEN - 1] = 0x00;
+        assert!(!is_eip1167_proxy(&bytecode));
+    }
+
+    #[test]
+    fn is_eip1167_rejects_full_contract_bytecode() {
+        // Realistic Vyper-compiled runtime starts with 0x60 (PUSH1) typically.
+        let bytecode = vec![0x60u8; 5000];
+        assert!(!is_eip1167_proxy(&bytecode));
+    }
+
+    #[test]
+    fn supported_chain_from_u64_known() {
+        assert_eq!(SupportedChain::from_u64(1), Some(SupportedChain::Mainnet));
+        assert_eq!(SupportedChain::from_u64(8453), Some(SupportedChain::Base));
+        assert_eq!(
+            SupportedChain::from_u64(42161),
+            Some(SupportedChain::Arbitrum)
+        );
+    }
+
+    #[test]
+    fn supported_chain_from_u64_unknown() {
+        assert_eq!(SupportedChain::from_u64(0), None);
+        assert_eq!(SupportedChain::from_u64(137), None); // Polygon: not yet supported
+    }
+
+    #[test]
+    fn detect_eth_variant_weth_paired_legacy() {
+        // CRV/ETH-style: direct deploy with WETH coin → ETH variant
+        let coins = [
+            addr("0xD533a949740bb3306d119CC777fa900bA034cd52"),
+            weth_mainnet(),
+        ];
+        let bytecode = vec![0x60u8; 5000]; // full deploy, not proxy
+        assert!(detect_eth_variant(
+            &coins,
+            &bytecode,
+            SupportedChain::Mainnet
+        ));
+    }
+
+    #[test]
+    fn detect_eth_variant_factory_no_weth() {
+        // CVG/crvFRAX-style: factory pool, no WETH → still ETH variant
+        let coins = [
+            addr("0x97efFB790f2fbB701D88f89DB4521348A2B77be8"),
+            addr("0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC"),
+        ];
+        let bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
+        assert!(detect_eth_variant(
+            &coins,
+            &bytecode,
+            SupportedChain::Mainnet
+        ));
+    }
+
+    #[test]
+    fn detect_eth_variant_legacy_direct_no_weth() {
+        // EURC/3Crv-style: legacy direct deploy, no WETH → non-ETH variant
+        let coins = [
+            addr("0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c"),
+            addr("0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"),
+        ];
+        let bytecode = vec![0x60u8; 5000]; // full deploy, not proxy
+        assert!(!detect_eth_variant(
+            &coins,
+            &bytecode,
+            SupportedChain::Mainnet
+        ));
     }
 }

--- a/crates/curve-adapter/src/lib.rs
+++ b/crates/curve-adapter/src/lib.rs
@@ -39,7 +39,10 @@ mod variant;
 #[cfg(feature = "build")]
 mod build;
 
-pub use detect::{detect_variant, DetectError, ProbingResults};
+pub use detect::{
+    detect_eth_variant, detect_variant, is_eip1167_proxy, DetectError, ProbingResults,
+    SupportedChain,
+};
 pub use variant::CurveVariant;
 
 #[cfg(feature = "build")]

--- a/crates/curve-adapter/tests/fuzz_registry.rs
+++ b/crates/curve-adapter/tests/fuzz_registry.rs
@@ -16,7 +16,7 @@
 //!     cargo test -p curve-adapter --test fuzz_registry -- fuzz_1 --ignored --nocapture
 
 use alloy::providers::{Provider, ProviderBuilder};
-use alloy_primitives::{address, Address, U256};
+use alloy_primitives::{Address, U256};
 use curve_adapter::{build_pool, CurveVariant, RawPoolState};
 use curve_math::Pool;
 use serde::Deserialize;
@@ -332,6 +332,7 @@ async fn read_and_build_pool(
     entry: &PoolEntry,
     provider: &BoxProvider,
     block: alloy::eips::BlockId,
+    chain: curve_adapter::SupportedChain,
 ) -> Option<(Pool, usize)> {
     let addr = Address::from_str(&entry.address).ok()?;
     let variant: CurveVariant = entry.variant.parse().ok()?;
@@ -600,45 +601,25 @@ async fn read_and_build_pool(
             let fee_gamma = c.fee_gamma().block(block).call().await.ok()?;
             let precs = c.precisions().block(block).call().await.ok();
 
-            // Detect ETH vs non-ETH variant for TwoCryptoV1 by probing on-chain.
-            // Try a small swap with both variants and pick the one that matches.
-            // This is the only reliable method — WETH presence doesn't determine
-            // the implementation (factory pools use ETH variant regardless of coins).
-            let eth_variant = if variant == CurveVariant::TwoCryptoV1 {
-                let probe_dx = U256::from(1_000_000_000_000_000u128); // 0.001 token
-                let on_chain = c
-                    .get_dy(U256::from(0), U256::from(1), probe_dx)
-                    .block(block)
-                    .call()
-                    .await;
-                match on_chain {
-                    Ok(expected) => {
-                        use curve_math::swap::twocrypto_v1::get_amount_out;
-                        let state_eth = RawPoolState {
-                            eth_variant: true,
-                            ..RawPoolState {
-                                variant,
-                                balances: vec![b0, b1],
-                                token_decimals: decimals.clone(),
-                                amp: ann,
-                                mid_fee: Some(mid_fee),
-                                out_fee: Some(out_fee),
-                                fee_gamma: Some(fee_gamma),
-                                d: Some(d),
-                                gamma: Some(gamma),
-                                price_scale: Some(vec![ps]),
-                                precisions: precs.clone().map(|p| p.to_vec()),
-                                ..Default::default()
-                            }
-                        };
-                        let pool_eth = build_pool(&state_eth).ok();
-                        let result_eth = pool_eth.and_then(|p| p.get_amount_out(0, 1, probe_dx));
-                        result_eth == Some(expected)
-                    }
-                    Err(_) => true, // default to ETH if probe fails
-                }
+            // Detect ETH vs non-ETH variant for TwoCryptoV1 via WETH-in-coins
+            // and EIP-1167 proxy bytecode signature. See `curve_adapter::detect`
+            // for the full rationale; in short, factory pools (proxies) always
+            // use the ETH variant, plus any direct deploy with WETH as a coin.
+            let eth_variant: Option<bool> = if variant == CurveVariant::TwoCryptoV1 {
+                let coin0 = c.coins(U256::from(0)).block(block).call().await.ok()?;
+                let coin1 = c.coins(U256::from(1)).block(block).call().await.ok()?;
+                let bytecode = provider
+                    .get_code_at(addr)
+                    .block_id(block)
+                    .await
+                    .unwrap_or_default();
+                Some(curve_adapter::detect_eth_variant(
+                    &[coin0, coin1],
+                    &bytecode,
+                    chain,
+                ))
             } else {
-                true // TwoCryptoNG always uses its own solver, eth_variant is ignored
+                None // TwoCryptoNG/TwoCryptoStable variants ignore this field
             };
 
             RawPoolState {
@@ -734,6 +715,8 @@ async fn fuzz_pools(label: &str, pools: &[PoolEntry]) {
         .split_whitespace()
         .find_map(|w| w.parse().ok())
         .unwrap_or(1);
+    let chain = curve_adapter::SupportedChain::from_u64(chain_id)
+        .expect("test running on chain not registered in SupportedChain — update detect.rs");
     let env_key = format!("RPC_URL_{chain_id}");
     let rpc_url = std::env::var(&env_key)
         .or_else(|_| std::env::var("RPC_URL"))
@@ -754,7 +737,7 @@ async fn fuzz_pools(label: &str, pools: &[PoolEntry]) {
     let mut pools_ok = 0u64;
 
     for entry in pools {
-        let (pool, n_coins) = match read_and_build_pool(entry, &provider, block).await {
+        let (pool, n_coins) = match read_and_build_pool(entry, &provider, block, chain).await {
             Some(p) => p,
             None => {
                 println!("  SKIP {}: could not read on-chain state", entry.name);


### PR DESCRIPTION
## What

- Replaces the ad-hoc on-chain probe in `fuzz_registry.rs` with `curve_adapter::detect_eth_variant(coins, bytecode, chain)` based on WETH-in-coins or EIP-1167 proxy bytecode.
- Adds `SupportedChain` enum (Mainnet / Base / Arbitrum) so adding a new chain forces a compile error on every per-chain constant lookup.
- Changes `RawPoolState.eth_variant` from `bool` (defaulting to `true`) to `Option<bool>` (defaulting to `None`); `build_pool` now errors instead of silently using a default for `TwoCryptoV1`. **Breaking change.**

## Why

The existing probe silently mis-classified `QUINTA/USDC` and `EURC/3Crv` as ETH variant when the probe-dx happened to give the same result for both Newton formulas, producing multi-wei `get_dy` mismatches and breaking CI. The probe also didn't generalize to substreams or RPC consumers. Detection logic only lived in the test.

The `Option<bool>` change closes a footgun: any consumer constructing `RawPoolState` with `..Default::default()` previously got `eth_variant=true`, which is wrong for the few legacy non-ETH direct deploys.