### PR TITLE
feat: classify TwoCryptoV1 eth_variant via deny-list

### DIFF
--- a/crates/curve-adapter/src/detect.rs
+++ b/crates/curve-adapter/src/detect.rs
@@ -229,78 +229,30 @@ const KNOWN_STETH: [Address; 1] = [
     address!("DC24316b9AE028F1497c275EB9192a3Ea0f67022"), // Lido stETH/ETH
 ];
 
-/// Standard EIP-1167 minimal proxy bytecode prefix (10 bytes).
-/// Followed by 20 bytes of implementation address, then [`EIP1167_SUFFIX`].
-const EIP1167_PREFIX: &[u8] = b"\x36\x3d\x3d\x37\x3d\x3d\x3d\x36\x3d\x73";
-
-/// Standard EIP-1167 minimal proxy bytecode suffix (15 bytes).
-const EIP1167_SUFFIX: &[u8] = b"\x5a\xf4\x3d\x82\x80\x3e\x90\x3d\x91\x60\x2b\x57\xfd\x5b\xf3";
-
-/// Total length of a standard EIP-1167 minimal proxy.
-const EIP1167_LEN: usize = 45;
-
-/// Returns `true` if `bytecode` is a standard EIP-1167 minimal proxy.
-///
-/// All three checks must pass: exact length, prefix, and suffix. This makes
-/// the false positive rate effectively zero — a non-proxy contract would
-/// have to coincidentally match all 25 fixed bytes at exact positions.
-pub fn is_eip1167_proxy(bytecode: &[u8]) -> bool {
-    bytecode.len() == EIP1167_LEN
-        && bytecode.starts_with(EIP1167_PREFIX)
-        && bytecode.ends_with(EIP1167_SUFFIX)
-}
-
-/// Chains supported by `curve_adapter` detection logic.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SupportedChain {
-    /// Ethereum Mainnet (chain ID 1).
-    Mainnet = 1,
-    /// Base (chain ID 8453).
-    Base = 8453,
-    /// Arbitrum One (chain ID 42161).
-    Arbitrum = 42161,
-}
-
-impl SupportedChain {
-    /// Convert a numeric chain ID to a `SupportedChain`. Returns `None` for
-    /// chains the adapter does not yet support.
-    pub fn from_u64(id: u64) -> Option<Self> {
-        match id {
-            1 => Some(Self::Mainnet),
-            8453 => Some(Self::Base),
-            42161 => Some(Self::Arbitrum),
-            _ => None,
-        }
-    }
-
-    /// Wrapped native token address (WETH on EVM chains).
-    pub fn wrapped_native(self) -> Address {
-        match self {
-            Self::Mainnet => address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
-            Self::Base => address!("4200000000000000000000000000000000000006"),
-            Self::Arbitrum => address!("82aF49447D8a07e3bd95BD0d56f35241523fBab1"),
-        }
-    }
-}
+/// Legacy `TwoCryptoV1` direct deploys that use the non-ETH Newton solver
+/// (`CurveCryptoSwap2.vy` template). Every other `TwoCryptoV1` pool — including
+/// all factory deploys (EIP-1167 proxies of `CurveCryptoSwap2ETH`) and
+/// WETH-paired direct deploys like the original CRV/ETH pool — uses the ETH
+/// variant. There is no factory that produces non-ETH pools, so this list is
+/// finite and grows at most when a new legacy direct deploy is discovered
+/// (typically surfaced by a fuzz mismatch). Each entry is verified by running
+/// both Newton variants locally against the on-chain `get_dy`.
+const KNOWN_NON_ETH_TWOCRYPTO_V1: [Address; 1] = [
+    address!("E84f5b1582BA325fDf9cE6B0c1F087ccfC924e54"), // EURC/3Crv (mainnet)
+];
 
 /// Detect whether a `TwoCryptoV1` pool uses the ETH variant Newton solver.
 ///
 /// `CurveCryptoSwap2ETH.vy` and `CurveCryptoSwap2.vy` differ in one Newton
-/// step (`mul2` formula). Detection rule:
-/// - Factory-deployed pools (EIP-1167 proxies pointing at the CryptoSwap
-///   factory implementation) **always** use the ETH variant, regardless of
-///   coin composition (e.g. CVG/crvFRAX has no WETH but uses ETH math).
-/// - Legacy direct deploys: `CurveCryptoSwap2ETH.vy` was used for
-///   WETH-paired pools (e.g. CRV/ETH); `CurveCryptoSwap2.vy` for the rest.
+/// step (`mul2` formula). Returns `true` for every pool not on the explicit
+/// non-ETH deny list. The current `TwoCryptoV1` factories deploy only ETH
+/// implementations, so newly indexed pools default to the correct variant.
 ///
-/// Combined check: `coins.contains(WETH) || is_eip1167_proxy(bytecode)`.
-///
-/// # Arguments
-/// * `coins` — pool's coin addresses (read from on-chain `coins(i)` getters)
-/// * `pool_bytecode` — runtime bytecode at the pool address (`eth_getCode`)
-/// * `chain` — chain on which the pool is deployed
-pub fn detect_eth_variant(coins: &[Address], pool_bytecode: &[u8], chain: SupportedChain) -> bool {
-    coins.contains(&chain.wrapped_native()) || is_eip1167_proxy(pool_bytecode)
+/// When a new legacy direct deploy on the non-ETH template is encountered,
+/// the registry fuzz test fails with a wei mismatch; add the address to
+/// [`KNOWN_NON_ETH_TWOCRYPTO_V1`] and re-run.
+pub fn detect_eth_variant(pool_addr: Address) -> bool {
+    !KNOWN_NON_ETH_TWOCRYPTO_V1.contains(&pool_addr)
 }
 
 #[cfg(test)]
@@ -656,111 +608,22 @@ mod tests {
 
     // ── eth_variant detection ──────────────────────────────────────────────
 
-    fn weth_mainnet() -> Address {
-        addr("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
-    }
-
-    /// Build a synthetic 45-byte EIP-1167 proxy with the given implementation address.
-    fn synthetic_proxy(impl_addr: Address) -> Vec<u8> {
-        let mut out = Vec::with_capacity(EIP1167_LEN);
-        out.extend_from_slice(EIP1167_PREFIX);
-        out.extend_from_slice(impl_addr.as_slice());
-        out.extend_from_slice(EIP1167_SUFFIX);
-        out
+    #[test]
+    fn detect_eth_variant_default_unknown_pool_is_eth() {
+        // Any address not in KNOWN_NON_ETH_TWOCRYPTO_V1 → ETH variant.
+        // Covers factory deploys, WETH-paired legacy, non-WETH ETH legacy.
+        let unknown = addr("0x0000000000000000000000000000000000000001");
+        assert!(detect_eth_variant(unknown));
     }
 
     #[test]
-    fn is_eip1167_recognizes_standard_proxy() {
-        let bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
-        assert!(is_eip1167_proxy(&bytecode));
-    }
-
-    #[test]
-    fn is_eip1167_rejects_wrong_length() {
-        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
-        bytecode.push(0x00);
-        assert!(!is_eip1167_proxy(&bytecode));
-    }
-
-    #[test]
-    fn is_eip1167_rejects_corrupted_prefix() {
-        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
-        bytecode[0] = 0xff;
-        assert!(!is_eip1167_proxy(&bytecode));
-    }
-
-    #[test]
-    fn is_eip1167_rejects_corrupted_suffix() {
-        let mut bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
-        bytecode[EIP1167_LEN - 1] = 0x00;
-        assert!(!is_eip1167_proxy(&bytecode));
-    }
-
-    #[test]
-    fn is_eip1167_rejects_full_contract_bytecode() {
-        // Realistic Vyper-compiled runtime starts with 0x60 (PUSH1) typically.
-        let bytecode = vec![0x60u8; 5000];
-        assert!(!is_eip1167_proxy(&bytecode));
-    }
-
-    #[test]
-    fn supported_chain_from_u64_known() {
-        assert_eq!(SupportedChain::from_u64(1), Some(SupportedChain::Mainnet));
-        assert_eq!(SupportedChain::from_u64(8453), Some(SupportedChain::Base));
-        assert_eq!(
-            SupportedChain::from_u64(42161),
-            Some(SupportedChain::Arbitrum)
-        );
-    }
-
-    #[test]
-    fn supported_chain_from_u64_unknown() {
-        assert_eq!(SupportedChain::from_u64(0), None);
-        assert_eq!(SupportedChain::from_u64(137), None); // Polygon: not yet supported
-    }
-
-    #[test]
-    fn detect_eth_variant_weth_paired_legacy() {
-        // CRV/ETH-style: direct deploy with WETH coin → ETH variant
-        let coins = [
-            addr("0xD533a949740bb3306d119CC777fa900bA034cd52"),
-            weth_mainnet(),
-        ];
-        let bytecode = vec![0x60u8; 5000]; // full deploy, not proxy
-        assert!(detect_eth_variant(
-            &coins,
-            &bytecode,
-            SupportedChain::Mainnet
-        ));
-    }
-
-    #[test]
-    fn detect_eth_variant_factory_no_weth() {
-        // CVG/crvFRAX-style: factory pool, no WETH → still ETH variant
-        let coins = [
-            addr("0x97efFB790f2fbB701D88f89DB4521348A2B77be8"),
-            addr("0x3175Df0976dFA876431C2E9eE6Bc45b65d3473CC"),
-        ];
-        let bytecode = synthetic_proxy(addr("0xa854b3df11afe1e54ddd2d62ce03a40bd0bba100"));
-        assert!(detect_eth_variant(
-            &coins,
-            &bytecode,
-            SupportedChain::Mainnet
-        ));
-    }
-
-    #[test]
-    fn detect_eth_variant_legacy_direct_no_weth() {
-        // EURC/3Crv-style: legacy direct deploy, no WETH → non-ETH variant
-        let coins = [
-            addr("0x1aBaEA1f7C830bD89Acc67eC4af516284b1bC33c"),
-            addr("0x6c3F90f043a72FA612cbac8115EE7e52BDe6E490"),
-        ];
-        let bytecode = vec![0x60u8; 5000]; // full deploy, not proxy
-        assert!(!detect_eth_variant(
-            &coins,
-            &bytecode,
-            SupportedChain::Mainnet
-        ));
+    fn detect_eth_variant_known_non_eth_pools() {
+        // Each entry in KNOWN_NON_ETH_TWOCRYPTO_V1 must classify as non-ETH.
+        for &pool in KNOWN_NON_ETH_TWOCRYPTO_V1.iter() {
+            assert!(
+                !detect_eth_variant(pool),
+                "{pool} should be non-ETH but detected as ETH"
+            );
+        }
     }
 }

--- a/crates/curve-adapter/src/lib.rs
+++ b/crates/curve-adapter/src/lib.rs
@@ -39,10 +39,7 @@ mod variant;
 #[cfg(feature = "build")]
 mod build;
 
-pub use detect::{
-    detect_eth_variant, detect_variant, is_eip1167_proxy, DetectError, ProbingResults,
-    SupportedChain,
-};
+pub use detect::{detect_eth_variant, detect_variant, DetectError, ProbingResults};
 pub use variant::CurveVariant;
 
 #[cfg(feature = "build")]

--- a/crates/curve-adapter/tests/fuzz_registry.rs
+++ b/crates/curve-adapter/tests/fuzz_registry.rs
@@ -332,7 +332,6 @@ async fn read_and_build_pool(
     entry: &PoolEntry,
     provider: &BoxProvider,
     block: alloy::eips::BlockId,
-    chain: curve_adapter::SupportedChain,
 ) -> Option<(Pool, usize)> {
     let addr = Address::from_str(&entry.address).ok()?;
     let variant: CurveVariant = entry.variant.parse().ok()?;
@@ -602,22 +601,11 @@ async fn read_and_build_pool(
             let precs = c.precisions().block(block).call().await.ok();
 
             // Detect ETH vs non-ETH variant for TwoCryptoV1 via WETH-in-coins
-            // and EIP-1167 proxy bytecode signature. See `curve_adapter::detect`
-            // for the full rationale; in short, factory pools (proxies) always
-            // use the ETH variant, plus any direct deploy with WETH as a coin.
+            // See `curve_adapter::detect_eth_variant` for the rationale: every
+            // TwoCryptoV1 pool uses the ETH variant unless explicitly listed
+            // in `KNOWN_NON_ETH_TWOCRYPTO_V1`.
             let eth_variant: Option<bool> = if variant == CurveVariant::TwoCryptoV1 {
-                let coin0 = c.coins(U256::from(0)).block(block).call().await.ok()?;
-                let coin1 = c.coins(U256::from(1)).block(block).call().await.ok()?;
-                let bytecode = provider
-                    .get_code_at(addr)
-                    .block_id(block)
-                    .await
-                    .unwrap_or_default();
-                Some(curve_adapter::detect_eth_variant(
-                    &[coin0, coin1],
-                    &bytecode,
-                    chain,
-                ))
+                Some(curve_adapter::detect_eth_variant(addr))
             } else {
                 None // TwoCryptoNG/TwoCryptoStable variants ignore this field
             };
@@ -715,8 +703,6 @@ async fn fuzz_pools(label: &str, pools: &[PoolEntry]) {
         .split_whitespace()
         .find_map(|w| w.parse().ok())
         .unwrap_or(1);
-    let chain = curve_adapter::SupportedChain::from_u64(chain_id)
-        .expect("test running on chain not registered in SupportedChain — update detect.rs");
     let env_key = format!("RPC_URL_{chain_id}");
     let rpc_url = std::env::var(&env_key)
         .or_else(|_| std::env::var("RPC_URL"))
@@ -737,7 +723,7 @@ async fn fuzz_pools(label: &str, pools: &[PoolEntry]) {
     let mut pools_ok = 0u64;
 
     for entry in pools {
-        let (pool, n_coins) = match read_and_build_pool(entry, &provider, block, chain).await {
+        let (pool, n_coins) = match read_and_build_pool(entry, &provider, block).await {
             Some(p) => p,
             None => {
                 println!("  SKIP {}: could not read on-chain state", entry.name);


### PR DESCRIPTION
All pools are ETH_VARIANT except one, which is hardcoded.