### PR TITLE
fix: classify MATH v0.1.1 as TwoCryptoStable

### DIFF
--- a/crates/curve-adapter/src/detect.rs
+++ b/crates/curve-adapter/src/detect.rs
@@ -68,7 +68,7 @@ pub struct ProbingResults {
     /// Pool has `MATH()` getter → TwoCrypto-NG with external math contract.
     pub has_math: bool,
 
-    /// Version string from `MATH().version()`. E.g. `"v2.0.0"`, `"v2.1.0"`, `"v0.1.0"`.
+    /// Version string from `MATH().version()`. E.g. `"v2.0.0"`, `"v2.1.0"`, `"v0.1.0"`, `"v0.1.1"`.
     pub math_version: Option<String>,
 
     /// Pool has `offpeg_fee_multiplier()` → StableSwapNG or StableSwapALend.
@@ -142,7 +142,8 @@ fn detect_cryptoswap(probing: &ProbingResults) -> Result<CurveVariant, DetectErr
             if probing.has_math {
                 match probing.math_version.as_deref() {
                     Some("v2.0.0" | "v2.1.0") => Ok(CurveVariant::TwoCryptoNG),
-                    Some("v0.1.0") => Ok(CurveVariant::TwoCryptoStable),
+                    // v0.1.1 only adds a balance-ratio assert to newton_D, same math as v0.1.0
+                    Some("v0.1.0" | "v0.1.1") => Ok(CurveVariant::TwoCryptoStable),
                     // Unknown MATH version — default to TwoCryptoNG
                     _ => Ok(CurveVariant::TwoCryptoNG),
                 }
@@ -344,6 +345,27 @@ mod tests {
             has_base_pool: false,
             has_int128_balances: false,
             pool_address: addr("0x6e5492F8ea2370844EE098A56DD88e1717e4A9C2"),
+        };
+        assert_eq!(
+            detect_variant(&probing).unwrap(),
+            CurveVariant::TwoCryptoStable
+        );
+    }
+
+    #[test]
+    fn detect_twocrypto_stable_v011() {
+        // CADD/frxUSD, deployed from the 2026 Twocrypto factory with StableswapMath v0.1.1
+        let probing = ProbingResults {
+            has_gamma: true,
+            n_coins: 2,
+            has_math: true,
+            math_version: Some("v0.1.1".to_string()),
+            has_offpeg_fee_multiplier: false,
+            has_stored_rates: false,
+            has_version: false,
+            has_base_pool: false,
+            has_int128_balances: false,
+            pool_address: addr("0x384CA8992F955009Bdd94849488E580559590157"),
         };
         assert_eq!(
             detect_variant(&probing).unwrap(),

--- a/crates/curve-adapter/src/variant.rs
+++ b/crates/curve-adapter/src/variant.rs
@@ -34,7 +34,7 @@ pub enum CurveVariant {
     /// Cardano cubic solver. MATH contract version v2.0.0 or v2.1.0.
     TwoCryptoNG,
     /// TwoCrypto-NG factory pools with StableSwap math.
-    /// Newton solver, gamma parameter ignored. MATH contract version v0.1.0.
+    /// Newton solver, gamma parameter ignored. MATH contract version v0.1.0 or v0.1.1.
     TwoCryptoStable,
     /// Legacy 3-coin CryptoSwap (tricrypto2: USDT/WBTC/WETH).
     /// Newton solver for y.

--- a/crates/curve-math/src/core/twocrypto_stable.rs
+++ b/crates/curve-math/src/core/twocrypto_stable.rs
@@ -1,4 +1,4 @@
-//! TwoCryptoStable — StableSwap math used by some TwoCryptoNG pools (MATH v0.1.0).
+//! TwoCryptoStable — StableSwap math used by some TwoCryptoNG pools (MATH v0.1.0/v0.1.1).
 //!
 //! These pools are deployed from the TwoCryptoNG factory but use StableSwap invariant
 //! instead of CryptoSwap. The gamma parameter is accepted but ignored.

--- a/crates/curve-math/src/pool.rs
+++ b/crates/curve-math/src/pool.rs
@@ -169,9 +169,9 @@ pub enum Pool {
         fee_gamma: U256,
     },
 
-    /// TwoCryptoNG pools using StableSwap MATH (v0.1.0).
+    /// TwoCryptoNG pools using StableSwap MATH (v0.1.0 or v0.1.1).
     /// CryptoSwap interface but StableSwap invariant (gamma ignored).
-    /// Detect via: pool.MATH().version() == "v0.1.0"
+    /// Detect via: pool.MATH().version() in {"v0.1.0", "v0.1.1"}
     TwoCryptoStable {
         balances: [U256; 2],
         precisions: [U256; 2],

--- a/crates/curve-math/src/swap/twocrypto_stable.rs
+++ b/crates/curve-math/src/swap/twocrypto_stable.rs
@@ -1,4 +1,4 @@
-//! Pool-level get_amount_out for TwoCryptoNG pools using StableSwap MATH (v0.1.0).
+//! Pool-level get_amount_out for TwoCryptoNG pools using StableSwap MATH (v0.1.0/v0.1.1).
 //!
 //! These pools are deployed from the TwoCryptoNG factory but use StableSwap invariant.
 //! Normalization and fee are CryptoSwap-style (price_scale, crypto_fee).

--- a/crates/curve-math/tools/index-pools.py
+++ b/crates/curve-math/tools/index-pools.py
@@ -133,6 +133,10 @@ TOKEN_ABI = json.loads('[{"name":"decimals","outputs":[{"type":"uint8"}],"inputs
 MATH_GETTER_ABI = json.loads('[{"name":"MATH","outputs":[{"type":"address"}],"inputs":[],"stateMutability":"view","type":"function"}]')
 VERSION_ABI = json.loads('[{"name":"version","outputs":[{"type":"string"}],"inputs":[],"stateMutability":"view","type":"function"}]')
 
+# MATH versions that are StableSwap math (TwoCryptoStable). v0.1.1 only adds a
+# balance-ratio assert to newton_D, same math as v0.1.0.
+STABLESWAP_MATH_VERSIONS = ("v0.1.0", "v0.1.1")
+
 # ABIs for on-chain variant probing (used by detect_variant_onchain)
 GAMMA_ABI = json.loads('[{"name":"gamma","outputs":[{"type":"uint256"}],"inputs":[],"stateMutability":"view","type":"function"}]')
 OFFPEG_ABI = json.loads('[{"name":"offpeg_fee_multiplier","outputs":[{"type":"uint256"}],"inputs":[],"stateMutability":"view","type":"function"}]')
@@ -240,7 +244,7 @@ def detect_variant_onchain(w3, addr, block):
             has_math, math_addr = _probe(w3, addr, MATH_GETTER_ABI, "MATH", block=block)
             if has_math and math_addr:
                 _, version = _probe(w3, math_addr, VERSION_ABI, "version", block=block)
-                if version == "v0.1.0":
+                if version in STABLESWAP_MATH_VERSIONS:
                     return "TwoCryptoStable"
                 return "TwoCryptoNG"
             return "TwoCryptoV1"
@@ -423,10 +427,10 @@ def discover_pools(w3, factory_cfg, existing_addrs, max_new, block):
         symbols = [s for _, s in info]
 
         variant = factory_cfg["variant"]
-        # Detect TwoCryptoStable: MATH v0.1.0 = StableSwap math
+        # Detect TwoCryptoStable: StableSwap MATH versions
         if variant == "TwoCryptoNG":
             math_ver = math_versions.get(addr, "v2.0.0")
-            if math_ver == "v0.1.0":
+            if math_ver in STABLESWAP_MATH_VERSIONS:
                 variant = "TwoCryptoStable"
         # MetaPool Factory: ask factory is_meta() to distinguish meta vs plain
         elif variant == "meta_factory":


### PR DESCRIPTION
## Problem

The scheduled Index Pools run fails on new pools deployed from the 2026 Twocrypto factory (pool version v3.0.0). They use StableswapMath v0.1.1, which detect_variant and index-pools.py do not recognize, so they fall through to the TwoCryptoNG default and get the wrong solver. v0.1.1 only adds an assert to newton_D, the math is the same as v0.1.0.

## Fix

Map "v0.1.1" to TwoCryptoStable in detect.rs and index-pools.py. Unknown future versions still default to TwoCryptoNG so the pending fuzz keeps catching them.

## Verification

Reconstructed the full 21-pool pending list from the failing run and fuzzed it with the fix: 606 passed, 0 failed. The fix reclassifies six v3.0.0 pools, including the CADD/frxUSD pool the run failed on.