### PR TITLE
fix(stableswap-v1): model delivered `exchange` output, not `get_dy` view

### DIFF
--- a/crates/curve-math/src/swap/stableswap_v1.rs
+++ b/crates/curve-math/src/swap/stableswap_v1.rs
@@ -1,6 +1,7 @@
 //! Pool-level get_amount_out for StableSwapV1 (3pool, ren, sbtc, hbtc).
 //!
-//! -1 offset. Denorm FIRST, then fee.
+//! -1 offset. Fee FIRST (in normalized units), then denorm — models the
+//! on-chain `exchange` (delivered) output, which can be `get_dy` or `get_dy - 1`.
 
 use alloy_primitives::U256;
 
@@ -30,10 +31,16 @@ pub fn get_amount_out(
     if xp[j] <= y_new {
         return None;
     }
-    // -1 offset. Denorm FIRST, then fee.
-    let dy = (xp[j] - y_new - U256::from(1)) * precision / rates[j];
+    // -1 offset. Subtract the fee in normalized units BEFORE the single
+    // `* PRECISION / rates[j]` denorm, matching the on-chain `exchange` (which
+    // does `dy -= dy*fee/FEE_DENOM` then `dy = dy * PRECISION / rates[j]`).
+    // `get_dy` instead denorms first and subtracts the fee after; because both
+    // are floor divisions, the two orders can differ by 1 wei, so `exchange`
+    // returns `get_dy` or `get_dy - 1`. Modeling the delivered `exchange` output
+    // (as StableSwapV2 already does) makes this wei-exact vs an actual swap.
+    let dy = xp[j] - y_new - U256::from(1);
     let fee_amount = fee * dy / U256::from(FEE_DENOMINATOR);
-    let result = dy - fee_amount;
+    let result = (dy - fee_amount) * precision / rates[j];
     if result.is_zero() {
         return None;
     }


### PR DESCRIPTION
StableSwapV1 (3pool era) `get_amount_out` denorms first, then subtracts the fee — replicating the pool’s `get_dy` **view**. But the state-changing `exchange` subtracts the fee in normalized units **before** the single `* PRECISION / rates[j]` denorm. Both steps are floor divisions, so the two orders disagree by 1 wei on some states, and `exchange` delivers `get_dy` or `get_dy - 1`.

### Fix
Reorder V1 `get_amount_out` to fee-first (identical to `stableswap_v2`, whose `get_dy` already uses the exchange ordering), so it returns what a swap actually **delivers**.

```rust
// before (get_dy view):
let dy = (xp[j] - y_new - 1) * PRECISION / rates[j];
let result = dy - fee*dy/FEE_DENOM;
// after (exchange delivery):
let dy = xp[j] - y_new - 1;
let result = (dy - fee*dy/FEE_DENOM) * PRECISION / rates[j];
```

### Verification
Checked against mainnet 3pool (`0xbEbc44…`) over many blocks on a revm fork: the delivered swap vs `get_dy` differs by 0 or 1 wei (~1-in-6 states), and the reordered result matches the delivered output **exactly**. StableSwapV0 (sUSD), V2, NG and CryptoSwap variants are unaffected — their `get_dy` already equals `exchange` (verified sUSD over 10 blocks: no divergence).

### Note
This changes V1 `get_amount_out` semantics from the `get_dy` view to the `exchange` delivery. Any fuzz/differential reference comparing V1 against `get_dy` should switch to a simulated `exchange`. Happy to follow up with that test change if you’d prefer it in this PR.